### PR TITLE
Update syslog-ng config to 4.5 and Elasticsearch to 8.7.1, also add Docker support

### DIFF
--- a/elasticsearch/template-network.json
+++ b/elasticsearch/template-network.json
@@ -1,12 +1,10 @@
-PUT _template/network?include_type_name
+PUT _index_template/network
 {
   "index_patterns": [
     "network-*"
   ],
-  "mappings": {
-    "mapping": {
-      "_source": {},
-      "_meta": {},
+  "template": {
+    "mappings": {
       "properties": {
         "@timestamp": {
           "type": "date"
@@ -241,7 +239,7 @@ PUT _template/network?include_type_name
         },
         "client" : {
           "type": "object",
-           "properties" : {
+            "properties" : {
               "port": {
                 "type": "integer",
                 "index": true,
@@ -256,18 +254,18 @@ PUT _template/network?include_type_name
                 "index": true,
                 "store": false
               }
-           }
+            }
         },
         "dns" : {
-           "properties" : {
+            "properties" : {
               "id" : {
-                 "type" : "keyword"
+                  "type" : "keyword"
               },
               "question.name" : {
-                 "type" : "keyword"
+                  "type" : "keyword"
               },
               "question.type" : {
-                 "type" : "keyword"
+                  "type" : "keyword"
               },
               "question.registered_domain": {
                   "type": "keyword",
@@ -279,10 +277,10 @@ PUT _template/network?include_type_name
                   }
               },
               "question.subdomain" : {
-                 "type" : "keyword"
+                  "type" : "keyword"
               },
               "question.top_level_domain" : {
-                 "type" : "keyword"
+                  "type" : "keyword"
               }
             }
         },

--- a/syslog-ng/etc/Dockerfile
+++ b/syslog-ng/etc/Dockerfile
@@ -15,6 +15,12 @@ ENV NETWORK_NAME="Balage Home"
 
 ENV PYTHONPATH=$PYTHONPATH:/etc/syslog-ng/python/
 
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt update && apt install --no-install-recommends -y python3-publicsuffix2 && rm -rf /var/lib/apt/lists/*
+
+RUN syslog-ng-update-virtualenv -y
+RUN /var/lib/syslog-ng/python-venv/bin/python3 -m pip install publicsuffixlist
+
 VOLUME /var/log
 
 # /etc/syslog-ng/GeoLite2-City.mmdb

--- a/syslog-ng/etc/Dockerfile
+++ b/syslog-ng/etc/Dockerfile
@@ -1,0 +1,20 @@
+FROM balabit/syslog-ng:4.5.0
+
+COPY syslog-ng/ /etc/syslog-ng/
+
+# Only for referencing what env values we rely on
+# One should overwrite them via ConfigMap or Secret
+ENV REMOTE_HOST="127.0.0.1"
+ENV REMOTE_PORT="9200"
+ENV REMOTE_SCHEME="http"
+ENV REMOTE_HOST_AND_PORT="${REMOTE_HOST}:${REMOTE_PORT}"
+ENV REMOTE_USER="user"
+ENV REMOTE_PASS="password"
+ENV DNS_SERVER="1.1.1.1"
+ENV NETWORK_NAME="Balage Home"
+
+ENV PYTHONPATH=$PYTHONPATH:/etc/syslog-ng/python/
+
+VOLUME /var/log
+
+# /etc/syslog-ng/GeoLite2-City.mmdb

--- a/syslog-ng/etc/Dockerfile
+++ b/syslog-ng/etc/Dockerfile
@@ -23,4 +23,5 @@ RUN /var/lib/syslog-ng/python-venv/bin/python3 -m pip install publicsuffixlist
 
 VOLUME /var/log
 
+# TODO fetch
 # /etc/syslog-ng/GeoLite2-City.mmdb

--- a/syslog-ng/etc/Dockerfile
+++ b/syslog-ng/etc/Dockerfile
@@ -2,17 +2,6 @@ FROM balabit/syslog-ng:4.5.0
 
 COPY syslog-ng/ /etc/syslog-ng/
 
-# Only for referencing what env values we rely on
-# One should overwrite them via ConfigMap or Secret
-ENV REMOTE_HOST="127.0.0.1"
-ENV REMOTE_PORT="9200"
-ENV REMOTE_SCHEME="http"
-ENV REMOTE_HOST_AND_PORT="${REMOTE_HOST}:${REMOTE_PORT}"
-ENV REMOTE_USER="user"
-ENV REMOTE_PASS="password"
-ENV DNS_SERVER="1.1.1.1"
-ENV NETWORK_NAME="Balage Home"
-
 ENV PYTHONPATH=$PYTHONPATH:/etc/syslog-ng/python/
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -23,5 +12,4 @@ RUN /var/lib/syslog-ng/python-venv/bin/python3 -m pip install publicsuffixlist
 
 VOLUME /var/log
 
-# TODO fetch
-# /etc/syslog-ng/GeoLite2-City.mmdb
+ENTRYPOINT ["/usr/sbin/syslog-ng", "-Fe"]

--- a/syslog-ng/etc/docker-compose.yaml
+++ b/syslog-ng/etc/docker-compose.yaml
@@ -2,15 +2,36 @@ version: '3'
 
 services:
 
-  db:
+  init-mmdb:
+    image: sng:latest
+    volumes:
+      - sng-etc:/etc/syslog-ng
+    user: "0"
+    entrypoint: >
+      bash -c 'wget https://github.com/P3TERX/GeoLite.mmdb/releases/download/2023.12.01/GeoLite2-City.mmdb -O /etc/syslog-ng/GeoLite2-City.mmdb'
+    healthcheck:
+      test: ["CMD-SHELL", "[ -f /etc/syslog-ng/GeoLite2-City.mmdb ]"]
+      interval: 1s
+      timeout: 5s
+      retries: 120
+
+  syslog-ng:
+    build:
+      context: ./
+      dockerfile: Dockerfile
     image: sng:latest
     restart: always
-    hostname: localhost/sng:latest
+    hostname: syslog-ng-openwrt-elk
     ports:
       - "6514:6514"
       - "514:514"
-   environment:
-     - FOO=bar
+    environment:
+      - REMOTE_HOST="es01"
+      - REMOTE_PORT="9200"
+      - REMOTE_USER="elastic"
+      - REMOTE_PASS="changeme"
+      - DNS_SERVER="1.2.3.4"
+      - NETWORK_NAME="Example Home"
     volumes:
       - sng-etc:/etc/syslog-ng
       - sng-log:/var/log
@@ -21,7 +42,15 @@ services:
         reservations:
           cpus: '0.75'
           memory: 256M
+    depends_on:
+      init-mmdb:
+        condition: service_healthy
 
 volumes:
   sng-etc:
   sng-log:
+
+networks:
+  default:
+    name: elastic
+    external: false

--- a/syslog-ng/etc/docker-compose.yaml
+++ b/syslog-ng/etc/docker-compose.yaml
@@ -1,0 +1,27 @@
+version: '3'
+
+services:
+
+  db:
+    image: sng:latest
+    restart: always
+    hostname: localhost/sng:latest
+    ports:
+      - "6514:6514"
+      - "514:514"
+   environment:
+     - FOO=bar
+    volumes:
+      - sng-etc:/etc/syslog-ng
+      - sng-log:/var/log
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+        reservations:
+          cpus: '0.75'
+          memory: 256M
+
+volumes:
+  sng-etc:
+  sng-log:

--- a/syslog-ng/etc/syslog-ng/conf.d/network-dnsmasq.conf
+++ b/syslog-ng/etc/syslog-ng/conf.d/network-dnsmasq.conf
@@ -65,7 +65,7 @@ destination d_dnsmasq_json {
 
 destination d_elastic_dnsmasq {
     elasticsearch-http(
-        url("http://`REMOTE_HOST`:`REMOTE_PORT`/_bulk")
+        url("https://`REMOTE_HOST`:`REMOTE_PORT`/_bulk")
         index("network-${S_YEAR}-${S_MONTH}")
         headers("Content-Type: application/x-ndjson")
         type("")
@@ -82,6 +82,7 @@ destination d_elastic_dnsmasq {
         log-fifo-size(20000)
         user("`REMOTE_USER`")
         password("`REMOTE_PASS`")
+        peer-verify(no)
     );
 };
 

--- a/syslog-ng/etc/syslog-ng/conf.d/network-dnsmasq.conf
+++ b/syslog-ng/etc/syslog-ng/conf.d/network-dnsmasq.conf
@@ -65,7 +65,7 @@ destination d_dnsmasq_json {
 
 destination d_elastic_dnsmasq {
     elasticsearch-http(
-        url("$(env REMOTE_SCHEME)://$(env REMOTE_HOST):$(env REMOTE_PORT)/_bulk")
+        url("http://`REMOTE_HOST`:`REMOTE_PORT`/_bulk")
         index("network-${S_YEAR}-${S_MONTH}")
         headers("Content-Type: application/x-ndjson")
         type("")

--- a/syslog-ng/etc/syslog-ng/conf.d/network-dnsmasq.conf
+++ b/syslog-ng/etc/syslog-ng/conf.d/network-dnsmasq.conf
@@ -1,13 +1,9 @@
-@define elastic_host "172.18.0.10:9200"
-@define elastic_user "user"
-@define elastic_pass "password"
-
 filter f_dnsmasq_query {
     match('query' value("MESSAGE"));
 #    match("query\[.+\]" value("MESSAGE"));
 };
 
-parser p_dns_csv {
+parser p_dnsmasq_csv {
     # dnsmasq[15458]: 744 172.18.0.5/47300 query[A] s.youtube.com from 172.18.0.5
     csv-parser(
         columns(dns.id, client_ip_port, dns.question.type, dns.question.name, from, client.ip)
@@ -31,7 +27,7 @@ parser p_dns_csv {
     map-value-pairs(
         # https://github.com/elastic/beats/blob/master/packetbeat/_meta/sample_outputs/dns.json
         pair("event.action",                "dns-query")
-        pair("destination.ip",              "172.18.0.20") # DNS server
+        pair("destination.ip",              "$(env DNS_SERVER)") # DNS server
         pair("event.category",              list("network")) # array
         pair("event.dataset",               "network.dns") # network.flow, network.dns, network.f2b
         pair("event.kind",                  "event")
@@ -64,16 +60,12 @@ destination d_dnsmasq_json {
     # ECS info: https://www.elastic.co/guide/en/beats/packetbeat/current/exported-fields-dns.html
     # https://github.com/elastic/ecs/issues/10
     # https://www.elastic.co/guide/en/ecs/current/ecs-client.html
-    file(
-        "/var/log/network/$HOST/$S_YEAR.$S_MONTH.$S_DAY/dns.json"
-        template("$(template t_network_dns)")
-        create-dirs(yes)
-    );
+    file("/var/log/dnsmasq.json" template("$(template t_network_dns)"));
 };
 
 destination d_elastic_dnsmasq {
     elasticsearch-http(
-        url("http://`elastic_host`/_bulk")
+        url("$(env REMOTE_SCHEME)://$(env REMOTE_HOST):$(env REMOTE_PORT)/_bulk")
         index("network-${S_YEAR}-${S_MONTH}")
         headers("Content-Type: application/x-ndjson")
         type("")
@@ -88,14 +80,14 @@ destination d_elastic_dnsmasq {
         )
         persist-name("dnsmasq")
         log-fifo-size(20000)
-        user("`elastic_user`")
-        password("`elastic_pass`")
+        user("$(env REMOTE_USER)")
+        password("$(env REMOTE_PASS)")
     );
 };
 
 destination d_network_dnsmasq {
     channel {
-        parser(p_dns_csv);
+        parser(p_dnsmasq_csv);
 #        destination(d_dnsmasq_json);
         destination(d_elastic_dnsmasq);
     };

--- a/syslog-ng/etc/syslog-ng/conf.d/network-dnsmasq.conf
+++ b/syslog-ng/etc/syslog-ng/conf.d/network-dnsmasq.conf
@@ -27,7 +27,7 @@ parser p_dnsmasq_csv {
     map-value-pairs(
         # https://github.com/elastic/beats/blob/master/packetbeat/_meta/sample_outputs/dns.json
         pair("event.action",                "dns-query")
-        pair("destination.ip",              "$(env DNS_SERVER)") # DNS server
+        pair("destination.ip",              "`DNS_SERVER`") # DNS server
         pair("event.category",              list("network")) # array
         pair("event.dataset",               "network.dns") # network.flow, network.dns, network.f2b
         pair("event.kind",                  "event")
@@ -80,8 +80,8 @@ destination d_elastic_dnsmasq {
         )
         persist-name("dnsmasq")
         log-fifo-size(20000)
-        user("$(env REMOTE_USER)")
-        password("$(env REMOTE_PASS)")
+        user("`REMOTE_USER`")
+        password("`REMOTE_PASS`")
     );
 };
 

--- a/syslog-ng/etc/syslog-ng/conf.d/network-fail2ban.conf
+++ b/syslog-ng/etc/syslog-ng/conf.d/network-fail2ban.conf
@@ -1,7 +1,3 @@
-@define elastic_host "172.18.0.10:9200"
-@define elastic_user "user"
-@define elastic_pass "password"
-
 filter f_fail2ban_stat {
     program("fail2ban-server")
     and (
@@ -37,7 +33,7 @@ parser p_fail2ban {
 
 destination d_elastic_fail2ban {
     elasticsearch-http(
-        url("http://`elastic_host`/_bulk")
+        url("$(env REMOTE_SCHEME)://$(env REMOTE_HOST):$(env REMOTE_PORT)/_bulk")
         index("network-${S_YEAR}-${S_MONTH}")
         headers("Content-Type: application/x-ndjson")
         type("")
@@ -52,8 +48,8 @@ destination d_elastic_fail2ban {
         )
         persist-name("fail2ban")
         log-fifo-size(20000)
-        user("`elastic_user`")
-        password("`elastic_pass`")
+        user("$(env REMOTE_USER)")
+        password("$(env REMOTE_PASS)")
     );
 };
 

--- a/syslog-ng/etc/syslog-ng/conf.d/network-fail2ban.conf
+++ b/syslog-ng/etc/syslog-ng/conf.d/network-fail2ban.conf
@@ -48,8 +48,8 @@ destination d_elastic_fail2ban {
         )
         persist-name("fail2ban")
         log-fifo-size(20000)
-        user("$(env REMOTE_USER)")
-        password("$(env REMOTE_PASS)")
+        user("`REMOTE_USER`")
+        password("`REMOTE_PASS`")
     );
 };
 

--- a/syslog-ng/etc/syslog-ng/conf.d/network-fail2ban.conf
+++ b/syslog-ng/etc/syslog-ng/conf.d/network-fail2ban.conf
@@ -33,7 +33,7 @@ parser p_fail2ban {
 
 destination d_elastic_fail2ban {
     elasticsearch-http(
-        url("$(env REMOTE_SCHEME)://$(env REMOTE_HOST):$(env REMOTE_PORT)/_bulk")
+        url("http://`REMOTE_HOST`:`REMOTE_PORT`/_bulk")
         index("network-${S_YEAR}-${S_MONTH}")
         headers("Content-Type: application/x-ndjson")
         type("")

--- a/syslog-ng/etc/syslog-ng/conf.d/network-fail2ban.conf
+++ b/syslog-ng/etc/syslog-ng/conf.d/network-fail2ban.conf
@@ -33,7 +33,7 @@ parser p_fail2ban {
 
 destination d_elastic_fail2ban {
     elasticsearch-http(
-        url("http://`REMOTE_HOST`:`REMOTE_PORT`/_bulk")
+        url("https://`REMOTE_HOST`:`REMOTE_PORT`/_bulk")
         index("network-${S_YEAR}-${S_MONTH}")
         headers("Content-Type: application/x-ndjson")
         type("")
@@ -50,6 +50,7 @@ destination d_elastic_fail2ban {
         log-fifo-size(20000)
         user("`REMOTE_USER`")
         password("`REMOTE_PASS`")
+        peer-verify(no)
     );
 };
 

--- a/syslog-ng/etc/syslog-ng/conf.d/network-ulogd2.conf
+++ b/syslog-ng/etc/syslog-ng/conf.d/network-ulogd2.conf
@@ -35,7 +35,7 @@ template t_network {
 
 destination d_elastic_network {
     elasticsearch-http(
-        url("$(env REMOTE_SCHEME)://$(env REMOTE_HOST):$(env REMOTE_PORT)/_bulk")
+        url("http://`REMOTE_HOST`:`REMOTE_PORT`/_bulk")
         index("network-${S_YEAR}-${S_MONTH}")
         headers("Content-Type: application/x-ndjson")
         type("")

--- a/syslog-ng/etc/syslog-ng/conf.d/network-ulogd2.conf
+++ b/syslog-ng/etc/syslog-ng/conf.d/network-ulogd2.conf
@@ -1,7 +1,3 @@
-@define elastic_host "172.18.0.10:9200"
-@define elastic_user "user"
-@define elastic_pass "password"
-
 filter f_ulogd_stat {
     program("ulogd")
     and (
@@ -39,7 +35,7 @@ template t_network {
 
 destination d_elastic_network {
     elasticsearch-http(
-        url("http://`elastic_host`/_bulk")
+        url("$(env REMOTE_SCHEME)://$(env REMOTE_HOST):$(env REMOTE_PORT)/_bulk")
         index("network-${S_YEAR}-${S_MONTH}")
         headers("Content-Type: application/x-ndjson")
         type("")
@@ -54,13 +50,13 @@ destination d_elastic_network {
         )
         persist-name("network2")
         log-fifo-size(20000)
-        user("`elastic_user`")
-        password("`elastic_pass`")
+        user("$(env REMOTE_USER)")
+        password("$(env REMOTE_PASS)")
     );
 };
 
-destination d_elastic_json {
-    file("/var/log/network.json" template("$(template t_network)"));
+destination d_ulogd_json {
+    file("/var/log/ulogd.json" template("$(template t_network)"));
 };
 
 destination d_network_ulogd {
@@ -89,7 +85,7 @@ destination d_network_ulogd {
                 pair("destination.port",            int("${outbound.DPT}")) # same as inbound.SPT
                 pair("destination.packets",         int("${inbound.PKTS}")) # reply is inbound from router pow
                 pair("network.type",                "ipv4")
-                pair("network.name",                "Balage Home")
+                pair("network.name",                "$(env NETWORK_NAME)")
                 pair("event.action",                "network_flow")
                 pair("event.category",              list("network")) # array
                 pair("event.dataset",               "network.flow") # network.flow, network.dns, network.f2b
@@ -122,7 +118,7 @@ destination d_network_ulogd {
         parser { geoip_ecs(); };
 
         filter(f_correlated_message);
-        #destination(d_elastic_json);
+        #destination(d_ulogd_json);
         destination(d_elastic_network);
     };
 };

--- a/syslog-ng/etc/syslog-ng/conf.d/network-ulogd2.conf
+++ b/syslog-ng/etc/syslog-ng/conf.d/network-ulogd2.conf
@@ -35,7 +35,7 @@ template t_network {
 
 destination d_elastic_network {
     elasticsearch-http(
-        url("http://`REMOTE_HOST`:`REMOTE_PORT`/_bulk")
+        url("https://`REMOTE_HOST`:`REMOTE_PORT`/_bulk")
         index("network-${S_YEAR}-${S_MONTH}")
         headers("Content-Type: application/x-ndjson")
         type("")
@@ -52,6 +52,7 @@ destination d_elastic_network {
         log-fifo-size(20000)
         user("`REMOTE_USER`")
         password("`REMOTE_PASS`")
+        peer-verify(no)
     );
 };
 

--- a/syslog-ng/etc/syslog-ng/conf.d/network-ulogd2.conf
+++ b/syslog-ng/etc/syslog-ng/conf.d/network-ulogd2.conf
@@ -50,8 +50,8 @@ destination d_elastic_network {
         )
         persist-name("network2")
         log-fifo-size(20000)
-        user("$(env REMOTE_USER)")
-        password("$(env REMOTE_PASS)")
+        user("`REMOTE_USER`")
+        password("`REMOTE_PASS`")
     );
 };
 
@@ -85,7 +85,7 @@ destination d_network_ulogd {
                 pair("destination.port",            int("${outbound.DPT}")) # same as inbound.SPT
                 pair("destination.packets",         int("${inbound.PKTS}")) # reply is inbound from router pow
                 pair("network.type",                "ipv4")
-                pair("network.name",                "$(env NETWORK_NAME)")
+                pair("network.name",                "`NETWORK_NAME`")
                 pair("event.action",                "network_flow")
                 pair("event.category",              list("network")) # array
                 pair("event.dataset",               "network.flow") # network.flow, network.dns, network.f2b

--- a/syslog-ng/etc/syslog-ng/conf.d/network-unbound.conf
+++ b/syslog-ng/etc/syslog-ng/conf.d/network-unbound.conf
@@ -1,66 +1,6 @@
-@define elastic_host "172.18.0.10:9200"
-@define elastic_user "user"
-@define elastic_pass "password"
-
 filter f_unbound_stat {
     program("unbound") and
     match(' IN' value("MESSAGE"));
-};
-
-python {
-
-"""
-from dns.question.name it parses:
-- dns.question.top_level_domain
-- dns.question.subdomain
-- dns.question.registered_domain
-by using publicsuffixlist from Mozilla
-"""
-
-import traceback
-from publicsuffixlist import PublicSuffixList
-
-with open("/usr/lib/python3.6/site-packages/publicsuffixlist/public_suffix_list.dat", "rb") as f:
-    psl = PublicSuffixList(f)
-
-class DNSSuffixResolver(object):
-    def init(self, options):
-        self.domain = options["domain"]
-        self.tld = options["tld"]
-        self.subdomain = options["subdomain"]
-        self.regdomain = options["regdomain"]
-        return True
-    def parse(self, log_message):
-        dom = str(log_message[self.domain].decode('utf-8'))
-        dom = dom.rstrip('.')
-        try:
-            if log_message['dns.question.type'].decode('utf-8') in ["A", "AAAA"]:
-
-                # Return longest publically shared suffix => top_level_domain
-                log_message[self.tld] = psl.publicsuffix(dom, accept_unknown=True)
-                # Return shortest suffix assigned for an individual. => registered_domain
-                log_message[self.regdomain] = str(psl.privatesuffix(dom, accept_unknown=True))
-                # Return tuple of labels and the private suffix. => subdomain
-                priv = psl.privateparts(dom)
-                if priv is not None:
-                    # most notorious is .amazonaws.com
-                    # https://github.com/google/guava/issues/1829
-                    concat=''
-                    for key in priv[ : -1 ]:
-                        concat += key + "."
-                    # Omit trailing dot.
-                    log_message[self.subdomain] = str(concat.rstrip('.'))
-                else:
-                    log_message[self.subdomain] = ''
-            else:
-                pass
-        except Exception:
-            traceback.print_tb
-            raise
-#            pass
-
-        # return True, other way message is dropped
-        return True
 };
 
 parser p_unbound_csv {
@@ -78,7 +18,7 @@ parser p_unbound_csv {
     map-value-pairs(
         # https://github.com/elastic/beats/blob/master/packetbeat/_meta/sample_outputs/dns.json
         pair("event.action",                "dns-query")
-        pair("destination.ip",              "172.18.0.1") # DNS server
+        pair("destination.ip",              "$(env DNS_SERVER)") # DNS server
         pair("event.category",              list("network")) # array
         pair("event.dataset",               "network.dns") # network.flow, network.dns, network.f2b
         pair("event.kind",                  "event")
@@ -91,7 +31,7 @@ parser p_unbound_csv {
     );
 
     python(
-        class("DNSSuffixResolver")
+        class("dnssuffixresolver.DNSSuffixResolver")
         options(
             "domain" "dns.question.name"
             "tld" "dns.question.top_level_domain"
@@ -107,7 +47,7 @@ template t_network_unbound {
 
 destination d_elastic_unbound {
     elasticsearch-http(
-        url("http://`elastic_host`/_bulk")
+        url("$(env REMOTE_SCHEME)://$(env REMOTE_HOST):$(env REMOTE_PORT)/_bulk")
         index("network-${S_YEAR}-${S_MONTH}")
         headers("Content-Type: application/x-ndjson")
         type("")
@@ -122,19 +62,19 @@ destination d_elastic_unbound {
         )
         persist-name("unbound")
         log-fifo-size(20000)
-        user("`elastic_user`")
-        password("`elastic_pass`")
+        user("$(env REMOTE_USER)")
+        password("$(env REMOTE_PASSWORD)")
     );
 };
 
-destination d_dns_json {
-    file("/var/log/dns.json" template("$(template t_network_unbound)"));
+destination d_unbound_json {
+    file("/var/log/unbound.json" template("$(template t_network_unbound)"));
 };
 
 destination d_network_unbound {
     channel {
         parser(p_unbound_csv);
-#        destination(d_dns_json);
+#        destination(d_unbound_json);
         destination(d_elastic_unbound);
     };
 };

--- a/syslog-ng/etc/syslog-ng/conf.d/network-unbound.conf
+++ b/syslog-ng/etc/syslog-ng/conf.d/network-unbound.conf
@@ -47,7 +47,7 @@ template t_network_unbound {
 
 destination d_elastic_unbound {
     elasticsearch-http(
-        url("http://`REMOTE_HOST`:`REMOTE_PORT`/_bulk")
+        url("https://`REMOTE_HOST`:`REMOTE_PORT`/_bulk")
         index("network-${S_YEAR}-${S_MONTH}")
         headers("Content-Type: application/x-ndjson")
         type("")
@@ -64,6 +64,7 @@ destination d_elastic_unbound {
         log-fifo-size(20000)
         user("`REMOTE_USER`")
         password("`REMOTE_PASS`")
+        peer-verify(no)
     );
 };
 

--- a/syslog-ng/etc/syslog-ng/conf.d/network-unbound.conf
+++ b/syslog-ng/etc/syslog-ng/conf.d/network-unbound.conf
@@ -47,7 +47,7 @@ template t_network_unbound {
 
 destination d_elastic_unbound {
     elasticsearch-http(
-        url("$(env REMOTE_SCHEME)://$(env REMOTE_HOST):$(env REMOTE_PORT)/_bulk")
+        url("http://`REMOTE_HOST`:`REMOTE_PORT`/_bulk")
         index("network-${S_YEAR}-${S_MONTH}")
         headers("Content-Type: application/x-ndjson")
         type("")

--- a/syslog-ng/etc/syslog-ng/conf.d/network-unbound.conf
+++ b/syslog-ng/etc/syslog-ng/conf.d/network-unbound.conf
@@ -18,7 +18,7 @@ parser p_unbound_csv {
     map-value-pairs(
         # https://github.com/elastic/beats/blob/master/packetbeat/_meta/sample_outputs/dns.json
         pair("event.action",                "dns-query")
-        pair("destination.ip",              "$(env DNS_SERVER)") # DNS server
+        pair("destination.ip",              "`DNS_SERVER`") # DNS server
         pair("event.category",              list("network")) # array
         pair("event.dataset",               "network.dns") # network.flow, network.dns, network.f2b
         pair("event.kind",                  "event")
@@ -62,8 +62,8 @@ destination d_elastic_unbound {
         )
         persist-name("unbound")
         log-fifo-size(20000)
-        user("$(env REMOTE_USER)")
-        password("$(env REMOTE_PASSWORD)")
+        user("`REMOTE_USER`")
+        password("`REMOTE_PASS`")
     );
 };
 

--- a/syslog-ng/etc/syslog-ng/conf.d/network.conf
+++ b/syslog-ng/etc/syslog-ng/conf.d/network.conf
@@ -58,7 +58,6 @@ filter f_remove_already_processed {
 log {
     source(s_network_ietf_syslog);
     source(s_network_bsd_syslog);
-    source(src);
 
     if (filter(f_ulogd_stat)) {
         destination(d_network_ulogd);

--- a/syslog-ng/etc/syslog-ng/conf.d/network.conf
+++ b/syslog-ng/etc/syslog-ng/conf.d/network.conf
@@ -1,9 +1,6 @@
-@define lan_ip "172.18.0.10"
-@define wan_ip "172.18.0.10"
-
-source s_network_wan{
+source s_network_ietf_syslog{
     syslog(
-        ip("`wan_ip`")
+        ip("0.0.0.0")
         port(6514)
         transport("tcp")
         log-fetch-limit(200)
@@ -27,9 +24,9 @@ source s_network_wan{
 #    );
 };
 
-source s_network_lan{
+source s_network_bsd_syslog{
     network(
-        ip("`lan_ip`")
+        ip("0.0.0.0")
         port(514)
         transport("tcp")
         log-fetch-limit(250)
@@ -59,8 +56,8 @@ filter f_remove_already_processed {
 };
 
 log {
-    source(s_network_wan);
-    source(s_network_lan);
+    source(s_network_ietf_syslog);
+    source(s_network_bsd_syslog);
     source(src);
 
     if (filter(f_ulogd_stat)) {

--- a/syslog-ng/etc/syslog-ng/conf.d/network.conf
+++ b/syslog-ng/etc/syslog-ng/conf.d/network.conf
@@ -67,16 +67,16 @@ log {
         destination(d_network_fail2ban);
         flags(final);
     }
-    #elif (filter(f_dnsmasq_query)){
+    # elif (filter(f_dnsmasq_query)){
     #    destination(d_network_dnsmasq);
     #    flags(final);
-    #};
+    # };
     elif (filter(f_unbound_stat)){
         destination(d_network_unbound);
         flags(final);
     };
 
-    filter(f_remove_already_processed);
-    destination(d_network);
+    # filter(f_remove_already_processed);
+    # destination(d_network);
 
 };

--- a/syslog-ng/etc/syslog-ng/python/dnssuffixresolver.py
+++ b/syslog-ng/etc/syslog-ng/python/dnssuffixresolver.py
@@ -7,12 +7,13 @@ by using publicsuffixlist from Mozilla
 """
 
 import traceback
+import syslogng
 from publicsuffixlist import PublicSuffixList
 
 with open("/usr/share/publicsuffix/public_suffix_list.dat", "rb") as f:
     psl = PublicSuffixList(f)
 
-class DNSSuffixResolver(object):
+class DNSSuffixResolver(syslogng.LogParser):
     def init(self, options):
         self.domain = options["domain"]
         self.tld = options["tld"]

--- a/syslog-ng/etc/syslog-ng/python/dnssuffixresolver.py
+++ b/syslog-ng/etc/syslog-ng/python/dnssuffixresolver.py
@@ -1,0 +1,53 @@
+"""
+from dns.question.name it parses:
+- dns.question.top_level_domain
+- dns.question.subdomain
+- dns.question.registered_domain
+by using publicsuffixlist from Mozilla
+"""
+
+import traceback
+from publicsuffixlist import PublicSuffixList
+
+with open("/usr/share/publicsuffix/public_suffix_list.dat", "rb") as f:
+    psl = PublicSuffixList(f)
+
+class DNSSuffixResolver(object):
+    def init(self, options):
+        self.domain = options["domain"]
+        self.tld = options["tld"]
+        self.subdomain = options["subdomain"]
+        self.regdomain = options["regdomain"]
+        return True
+    def parse(self, log_message):
+        dom = str(log_message[self.domain].decode('utf-8'))
+        dom = dom.rstrip('.')
+        try:
+            if log_message['dns.question.type'].decode('utf-8') in ["A", "AAAA"]:
+
+                # Return longest publically shared suffix => top_level_domain
+                log_message[self.tld] = psl.publicsuffix(dom, accept_unknown=True)
+                # Return shortest suffix assigned for an individual. => registered_domain
+                log_message[self.regdomain] = str(psl.privatesuffix(dom, accept_unknown=True))
+                # Return tuple of labels and the private suffix. => subdomain
+                priv = psl.privateparts(dom)
+                if priv is not None:
+                    # most notorious is .amazonaws.com
+                    # https://github.com/google/guava/issues/1829
+                    concat=''
+                    for key in priv[ : -1 ]:
+                        concat += key + "."
+                    # Omit trailing dot.
+                    log_message[self.subdomain] = str(concat.rstrip('.'))
+                else:
+                    log_message[self.subdomain] = ''
+            else:
+                pass
+        except Exception:
+            traceback.print_tb
+            raise
+#            pass
+
+        # return True, other way message is dropped
+        return True
+

--- a/syslog-ng/etc/syslog-ng/syslog-ng.conf
+++ b/syslog-ng/etc/syslog-ng/syslog-ng.conf
@@ -1,215 +1,35 @@
-@version:3.26
+@version:4.5
 @include "scl.conf"
-
-#
-# /etc/syslog-ng/syslog-ng.conf
-#
-# File format description can be found in syslog-ng.conf(5)
-# and in /usr/share/doc/packages/syslog-ng/syslog-ng.txt.
-#
-# NOTE: The SuSEconfig script and its syslog-ng.conf.in
-#       configuration template aren't used any more.
-#
-#       Feel free to edit this file directly.
-#
 
 #
 # Global options.
 #
-options { chain_hostnames(off); flush_lines(0); perm(0640); stats_freq(3600); threaded(yes); ts-format(iso); };
-
-#
-# 'src' is our main source definition. you can add
-# more sources driver definitions to it, or define
-# your own sources, i.e.:
-#
-#source my_src { .... };
-#
-source src {
-	#
-	# use system() for local logs
-	#
-	system();
-	#
-	# syslog-ng's internal messages
-	#
-	internal();
-	#
-	# uncomment to process log messages from network:
-	#
-	#udp(ip("0.0.0.0") port(514));
+options {
+    chain_hostnames(off);
+    flush_lines(0);
+    perm(0640);
+    stats_freq(3600);
+    threaded(yes);
+    ts-format(iso);
 };
 
-@include "/run/syslog-ng/additional-log-sockets.conf"
-
-#
-# Filter definitions
-#
-filter f_iptables   { facility(kern) and message("IN=") and message("OUT="); };
-
-filter f_console    { level(warn) and facility(kern) and not filter(f_iptables)
-                      or level(err) and not facility(authpriv); };
-
-filter f_newsnotice { level(notice) and facility(news); };
-filter f_newscrit   { level(crit)   and facility(news); };
-filter f_newserr    { level(err)    and facility(news); };
-filter f_news       { facility(news); };
-
-filter f_mailinfo   { level(info)      and facility(mail); };
-filter f_mailwarn   { level(warn)      and facility(mail); };
-filter f_mailerr    { level(err, crit) and facility(mail); };
-filter f_mail       { facility(mail); };
-
-filter f_cron       { facility(cron); };
-
-filter f_local      { facility(local0, local1, local2, local3,
-                               local4, local5, local6, local7); };
-
-#
-# acpid messages
-#
-filter f_acpid_full { program('acpid'); };
-filter f_acpid      { level(emerg..notice) and program('acpid'); };
-
-# this is for the old acpid < 1.0.6
-filter f_acpid_old  { program('^\[acpid\]$'); };
-
-filter f_netmgm     { program('NetworkManager') or program('nm-dispatcher'); };
-
-filter f_messages   { not facility(news, mail) and not filter(f_iptables) and not filter(f_ulogd) and not filter(f_unbound); };
-filter f_warn       { level(warn, err, crit) and not filter(f_iptables); };
-filter f_alert      { level(alert); };
+source s_local {
+    internal();
+};
 
 
-#
-# Enable this and adopt IP to send log messages to a log server.
-#
-#destination logserver { udp("10.10.10.10" port(514)); };
-#log { source(src); destination(logserver); };
+###
+# Only store internal
+###
+destination d_local { file("/var/log/messages" suppress(30) owner(-1) group(-1) perm(-1)); };
 
-#
-# Enable this, if you want to keep all messages in one file:
-# (don't forget to provide logrotation config)
-#
-#destination allmessages { file("/var/log/allmessages"); };
-#log { source(src); destination(allmessages); };
-
-#
-# Most warning and errors on tty10 and on the xconsole pipe:
-#
-destination console  { file("/dev/tty10"    suppress(30) owner(-1) group(-1) perm(-1)); };
-log { source(src); source(chroots); filter(f_console); destination(console); };
-
-destination xconsole { pipe("/dev/xconsole" suppress(30) owner(-1) group(-1) perm(-1)); };
-log { source(src); source(chroots); filter(f_console); destination(xconsole); };
-
-# Enable this, if you want that root is informed immediately,
-# e.g. of logins:
-#
-#destination root { usertty("root"); };
-#log { source(src); source(chroots); filter(f_alert); destination(root); };
-
-
-#
-# News-messages in separate files:
-#
-destination newscrit   { file("/var/log/news/news.crit"
-                              suppress(30) owner(news) group(news)); };
-log { source(src); source(chroots); filter(f_newscrit); destination(newscrit); };
-
-destination newserr    { file("/var/log/news/news.err"
-                              suppress(30) owner(news) group(news)); };
-log { source(src); source(chroots); filter(f_newserr); destination(newserr); };
-
-destination newsnotice { file("/var/log/news/news.notice"
-                              suppress(30) owner(news) group(news)); };
-log { source(src); source(chroots); filter(f_newsnotice); destination(newsnotice); };
-
-#
-# and optionally also all in one file:
-# (don't forget to provide logrotation config)
-#
-#destination news { file("/var/log/news.all"); };
-#log { source(src); source(chroots); filter(f_news); destination(news); };
-
-
-#
-# Mail-messages in separate files:
-#
-destination mailinfo { file("/var/log/mail.info" suppress(30)); };
-log { source(src); source(chroots); filter(f_mailinfo); destination(mailinfo); };
-
-destination mailwarn { file("/var/log/mail.warn" suppress(30)); };
-log { source(src); source(chroots); filter(f_mailwarn); destination(mailwarn); };
-
-destination mailerr  { file("/var/log/mail.err"  suppress(30) fsync(yes)); };
-log { source(src); source(chroots); filter(f_mailerr);  destination(mailerr); };
-
-#
-# and also all in one file:
-#
-destination mail { file("/var/log/mail" suppress(30)); };
-log { source(src); source(chroots); filter(f_mail); destination(mail); };
-
- 
-#
-# acpid messages in one file:
-#
-destination acpid { file("/var/log/acpid" suppress(30)); };
-destination devnull { };
-log { source(src); source(chroots); filter(f_acpid); destination(acpid); flags(final); };
-#
-# if you want more verbose acpid logging, comment the destination(null)
-# line and uncomment the destination(acpid) line
-#
-log { source(src); source(chroots); filter(f_acpid_full); destination(devnull); flags(final); };
-# log { source(src); source(chroots); filter(f_acpid_full); destination(acpid); flags(final); };
-#
-# old acpid < 1.0.6
-log { source(src); source(chroots); filter(f_acpid_old); destination(acpid); flags(final); };
-
-#
-# NetworkManager messages in one file:
-#
-destination netmgm { file("/var/log/NetworkManager" suppress(30)); };
-log { source(src); source(chroots); filter(f_netmgm); destination(netmgm); flags(final); };
-
-
-#
-# Cron-messages in one file:
-# (don't forget to provide logrotation config)
-#
-#destination cron { file("/var/log/cron" suppress(30)); };
-#log { source(src); source(chroots); filter(f_cron); destination(cron); };
-
-
-#
-# Some boot scripts use/require local[1-7]:
-#
-destination localmessages { file("/var/log/localmessages" suppress(30)); };
-log { source(src); source(chroots); filter(f_local); destination(localmessages); };
-
-
-#
-# All messages except iptables and the facilities news and mail:
-#
-destination messages { file("/var/log/messages" suppress(30) owner(-1) group(-1) perm(-1)); };
-log { source(src); source(chroots); filter(f_messages); destination(messages); };
-
-
-#
-# Firewall (iptables) messages in one file:
-#
-destination firewall { file("/var/log/firewall" suppress(30)); };
-log { source(src); source(chroots); filter(f_iptables); destination(firewall); };
-
-
-#
-# Warnings (except iptables) in one file:
-#
-destination warn { file("/var/log/warn" suppress(30) fsync(yes)); };
-log { source(src); source(chroots); filter(f_warn); destination(warn); };
-
+###
+# Only enabled this in case you want to persists syslog-ng's own logs on a PV
+###
+# log {
+#     source(src_local);
+#     destination(d_local);
+# };
 
 ###
 # Include all config files in /etc/syslog-ng/conf.d/

--- a/syslog-ng/etc/syslog-ng/syslog-ng.conf
+++ b/syslog-ng/etc/syslog-ng/syslog-ng.conf
@@ -26,7 +26,7 @@ destination d_local { file("/var/log/messages" suppress(30) owner(-1) group(-1) 
 # Only enabled this in case you want to persists syslog-ng's own logs on a PV
 ###
 # log {
-#     source(src_local);
+#     source(s_local);
 #     destination(d_local);
 # };
 

--- a/syslog-ng/etc/syslog-ng/syslog-ng.conf
+++ b/syslog-ng/etc/syslog-ng/syslog-ng.conf
@@ -8,7 +8,6 @@ options {
     chain_hostnames(off);
     flush_lines(0);
     perm(0640);
-    stats_freq(3600);
     threaded(yes);
     ts-format(iso);
 };


### PR DESCRIPTION
syslog-ng's configuration has been refactored and updated to match up version 4.5.0, also many hard wired settings are now populated via environment variables.

A Dockerfile is provided to help people who requires container images. This image is only meant for transforming fail2ban, dnsmasq, unbound and ulogd2 logs to Elasticsearch. Although you can send any kind of logs to TCP 6514 (IETF syslog) or TCP 514 (BSD syslog) of the container, do not expect them to be properly indexed by Elasticsearch.

Be aware. The Dockerfile initializes a copy of GeoLite2-City.mmdb from a 3rd party site. It is only for testing, implement your own [method to fetch maps complying to the license requirements](https://dev.maxmind.com/geoip/updating-databases).

The "network" legacy index template has been converted to composable template. Tested it with Elasticsearch 8.7.1

Elasticsearch was installed by using this [elkninja/elastic-stack-docker-part-one/docker-compose.yaml](https://github.com/elkninja/elastic-stack-docker-part-one/tree/main).